### PR TITLE
関数名を命名規則に合わせて修正

### DIFF
--- a/docs/files/src-penguin-syan-php-form-4-expt-sample-phpdoc.html
+++ b/docs/files/src-penguin-syan-php-form-4-expt-sample-phpdoc.html
@@ -111,7 +111,7 @@
 
 <dl class="phpdocumentor-table-of-contents">
                             <dt class="phpdocumentor-table-of-contents__entry -function -">
-    <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sample_func">sample_func()</a>
+    <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc">sampleFunc()</a>
     <span>
                                 &nbsp;: string    </span>
 </dt>
@@ -129,9 +129,9 @@
             <a href="files/src-penguin-syan-php-form-4-expt-sample-phpdoc.html#functions" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -function - -deprecated">
-    <h4 class="phpdocumentor-element__name" id="function_sample_func">
-        sample_func()
-        <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sample_func" class="headerlink"><i class="fas fa-link"></i></a>
+    <h4 class="phpdocumentor-element__name" id="function_sampleFunc">
+        sampleFunc()
+        <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/penguin_syan/php_form_4_expt/sample_phpDoc.php"><a href="files/src-penguin-syan-php-form-4-expt-sample-phpdoc.html"><abbr title="src/penguin_syan/php_form_4_expt/sample_phpDoc.php">sample_phpDoc.php</abbr></a></abbr>
@@ -144,7 +144,7 @@
 
     <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility"></span>
-                <span class="phpdocumentor-signature__name">sample_func</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$id</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+                    <span class="phpdocumentor-signature__name">sampleFunc</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$id</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>PHPDocの動作及びその結果を確認するために作成された関数．
 ライブラリとしては本関数に意味はなく，ある程度開発が進んだ段階で削除する．

--- a/docs/js/searchIndex.js
+++ b/docs/js/searchIndex.js
@@ -1,10 +1,10 @@
 Search.appendIndex(
     [
                 {
-            "fqsen": "\\penguin_syan\\php_form_4_expt\\sample_func\u0028\u0029",
-            "name": "sample_func",
+            "fqsen": "\\penguin_syan\\php_form_4_expt\\sampleFunc\u0028\u0029",
+            "name": "sampleFunc",
             "summary": "\u30B5\u30F3\u30D7\u30EB\u95A2\u6570",
-            "url": "namespaces/penguin-syan-php-form-4-expt.html#function_sample_func"
+            "url": "namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc"
         },                {
             "fqsen": "\\",
             "name": "\\",

--- a/docs/namespaces/penguin-syan-php-form-4-expt.html
+++ b/docs/namespaces/penguin-syan-php-form-4-expt.html
@@ -106,7 +106,7 @@
 
 <dl class="phpdocumentor-table-of-contents">
                             <dt class="phpdocumentor-table-of-contents__entry -function -">
-    <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sample_func">sample_func()</a>
+    <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc">sampleFunc()</a>
     <span>
                                 &nbsp;: string    </span>
 </dt>
@@ -122,9 +122,9 @@
             <a href="namespaces/penguin-syan-php-form-4-expt.html#functions" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -function - -deprecated">
-    <h4 class="phpdocumentor-element__name" id="function_sample_func">
-        sample_func()
-        <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sample_func" class="headerlink"><i class="fas fa-link"></i></a>
+    <h4 class="phpdocumentor-element__name" id="function_sampleFunc">
+        sampleFunc()
+        <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/penguin_syan/php_form_4_expt/sample_phpDoc.php"><a href="files/src-penguin-syan-php-form-4-expt-sample-phpdoc.html"><abbr title="src/penguin_syan/php_form_4_expt/sample_phpDoc.php">sample_phpDoc.php</abbr></a></abbr>
@@ -137,7 +137,7 @@
 
     <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility"></span>
-                <span class="phpdocumentor-signature__name">sample_func</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$id</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+                    <span class="phpdocumentor-signature__name">sampleFunc</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$id</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>PHPDocの動作及びその結果を確認するために作成された関数．
 ライブラリとしては本関数に意味はなく，ある程度開発が進んだ段階で削除する．

--- a/docs/packages/Application.html
+++ b/docs/packages/Application.html
@@ -105,7 +105,7 @@
 
 <dl class="phpdocumentor-table-of-contents">
                             <dt class="phpdocumentor-table-of-contents__entry -function -">
-    <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sample_func">sample_func()</a>
+    <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc">sampleFunc()</a>
     <span>
                                 &nbsp;: string    </span>
 </dt>
@@ -121,9 +121,9 @@
             <a href="packages/Application.html#functions" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -function - -deprecated">
-    <h4 class="phpdocumentor-element__name" id="function_sample_func">
-        sample_func()
-        <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sample_func" class="headerlink"><i class="fas fa-link"></i></a>
+    <h4 class="phpdocumentor-element__name" id="function_sampleFunc">
+        sampleFunc()
+        <a href="namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/penguin_syan/php_form_4_expt/sample_phpDoc.php"><a href="files/src-penguin-syan-php-form-4-expt-sample-phpdoc.html"><abbr title="src/penguin_syan/php_form_4_expt/sample_phpDoc.php">sample_phpDoc.php</abbr></a></abbr>
@@ -136,7 +136,7 @@
 
     <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility"></span>
-                <span class="phpdocumentor-signature__name">sample_func</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$id</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+                    <span class="phpdocumentor-signature__name">sampleFunc</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$id</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>PHPDocの動作及びその結果を確認するために作成された関数．
 ライブラリとしては本関数に意味はなく，ある程度開発が進んだ段階で削除する．

--- a/docs/reports/deprecated.html
+++ b/docs/reports/deprecated.html
@@ -113,7 +113,7 @@
                 </tr>
                                                             <tr>
                             <td class="phpdocumentor-cell">17</td>
-                            <td class="phpdocumentor-cell"><a href="namespaces/penguin-syan-php-form-4-expt.html#function_sample_func"><abbr title="\penguin_syan\php_form_4_expt\sample_func()">sample_func()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><a href="namespaces/penguin-syan-php-form-4-expt.html#function_sampleFunc"><abbr title="\penguin_syan\php_form_4_expt\sampleFunc()">sampleFunc()</abbr></a></td>
                             <td class="phpdocumentor-cell"><p>PHPDocのサンプル用関数の為，非推奨どころか使用禁止．</p>
 </td>
                         </tr>

--- a/src/penguin_syan/php_form_4_expt/sample_phpDoc.php
+++ b/src/penguin_syan/php_form_4_expt/sample_phpDoc.php
@@ -3,17 +3,17 @@ namespace penguin_syan\php_form_4_expt;
 
 /**
  * サンプル関数
- * 
+ *
  * PHPDocの動作及びその結果を確認するために作成された関数．
  * ライブラリとしては本関数に意味はなく，ある程度開発が進んだ段階で削除する．
  * 当然，ライブラリとしてこの関数を使用することは厳禁である．
  *
  * @deprecated PHPDocのサンプル用関数の為，非推奨どころか使用禁止．
- * 
+ *
  * @param int $id ユーザID
  * @param string $name ユーザ名
  * @return string ユーザIDとユーザ名を結合した文字列
  */
-function sample_func(int $id, string $name){
+function sampleFunc(int $id, string $name){
     return "ユーザIDが".$id."の人は".$name."さんです．";
 }


### PR DESCRIPTION
**変更の概要**  
サンプル用関数の名称を変更．

**変更理由**  
サンプル用関数を命名規則に基づいたものにするための修正．

**変更内容**
今回の変更により，ライブラリの使用方法に生じた変更を記載します（必須）．  
例えば，関数の引数の変更や関数名の変更などが該当します．  

*変更前* 
関数名：`sample_func`

*変更後*  
関数名：`sampleFunc`