### PR TITLE
ライセンスに関する記述を修正

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 penguin-syan
+Copyright (c) 2022 HSSLab.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -70,3 +70,8 @@ use function penguin_syan\php_form_4_expt\<FUNCTION_NAME>;
 
 本ライブラリの利用に関する詳細は[ドキュメント](https://penguin-syan.github.io/PHP-Form-4-Expt/)を参照すること．
 開発者用データは[Wiki](https://github.com/penguin-syan/PHP-Form-4-Expt/wiki)を参照すること．
+
+## ⚖️ ライセンス
+Copyright (c) 2022 HSSLab.  
+This code is released under the MIT license.  
+See [LICENSE](https://github.com/penguin-syan/PHP-Form-4-Expt/blob/main/LICENSE) or [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "penguin-syan/php-form-4-expt",
     "description": "研究で使用するPHPベースのアンケートフォーム作成用ライブラリ",
     "type": "library",
-    "license": "Released by penguin_syan under the MIT License.",
+    "license": "Released by HSSLab under the MIT License.",
     "autoload": {
         "psr-4": {
             "penguin_syan\\php_form_4_expt\\": "src/"
@@ -10,8 +10,8 @@
     },
     "authors": [
         {
-            "name": "penguin-syan",
-            "email": "member@penguin-syan.tokyo"
+            "name": "HSSLab",
+            "email": "hai2016jinroh@gmail.com"
         }
     ],
     "require": {}


### PR DESCRIPTION
**変更の概要**  
ライセンスに関する記述を追加．

**変更理由**  
本ライブラリをMITライセンスによるオープンソース化するにあたり，  
著作権者の表記を変更したため．

**変更内容**  
著作権者の表記をデフォルトの`penguin-syan`から`HSS Lab`に変更．