### PR TITLE
[dev-011]セクションの作成

### DIFF
--- a/src/group_section.php
+++ b/src/group_section.php
@@ -9,20 +9,20 @@ namespace penguin_syan\php_form_4_expt;
  * 
  * 
  * 使用例
- * $group1 = ["penguin_syan\php_form_4_expt\\random_section",
+ * $group1 = ["random_section",
  *             [
- *               ['penguin_syan\php_form_4_expt\\video','./movie.mp4', ObjectSize::SMALL_FULL , 1],
- *               ["penguin_syan\php_form_4_expt\\video",'./movie.mp4', ObjectSize::SMALL, 2],
- *               ["penguin_syan\php_form_4_expt\\video",'./movie.mp4', ObjectSize::SMALL, 3],
- *               ['penguin_syan\php_form_4_expt\video','./movie.mp4', ObjectSize::SMALL_FULL , 4]
+ *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 1],
+ *               ["video",'./movie.mp4', ObjectSize::SMALL, 2],
+ *               ["video",'./movie.mp4', ObjectSize::SMALL, 3],
+ *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 4]
  *             ]
  *           ];
  *
- * $group2 = ["penguin_syan\php_form_4_expt\\random_section",
+ * $group2 = ["random_section",
  *             [
- *               ["penguin_syan\php_form_4_expt\\likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
- *               ["penguin_syan\php_form_4_expt\\likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
- *               ["penguin_syan\php_form_4_expt\\likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true]
+ *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
+ *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
+ *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true]
  *             ]
  *           ];
  *

--- a/src/group_section.php
+++ b/src/group_section.php
@@ -2,10 +2,7 @@
 namespace penguin_syan\php_form_4_expt;
 
 /**
- * 複数の質問をまとめて扱うセクションを作成するための関数
- * 
- * 本関数を使用すると，複数の質問項目をまとめて扱うことができる．
- * また、必要に応じてページ内で表示順序を入れ替えることができる．
+ * 複数の質問をまとめて扱うセクションを作成するためのclass
  * 
  * 
  * 使用例
@@ -23,14 +20,27 @@ namespace penguin_syan\php_form_4_expt;
  * group_section::group_section([$group1,$group2]);
  * 
  * 
- * @param array $lib_function [string 関数名, 実行する関数の引数] ライブラリに実装された関数の配列
  */
 class group_section {
 
+    /**
+     * section作成用にメソッド名と引数を配列にして返すメソッド
+     * 
+     * @param array $lib_function 
+     * @return array
+     */
     public static function group_section_array(array $lib_function){
         return ['group_section', $lib_function];
     }
 
+    /**
+     * 複数の質問をまとめて扱うセクションを作成するための関数
+     * 
+     * 本関数を使用すると，複数の質問項目をまとめて扱うことができる．
+     * また、必要に応じてページ内で表示順序を入れ替えることができる
+     * 
+     * @param array $lib_function [string 関数名, 実行する関数の引数] ライブラリに実装された関数の配列
+     */
     public static function group_section(array $lib_function){
         if (is_array($lib_function[0])){
             foreach ($lib_function as $function) {
@@ -45,13 +55,28 @@ class group_section {
         }
     }
 }
-
+/**
+ * 複数の質問をまとめて扱い、順番をランダムにするセクションを作成するためのclass.
+ */
 class random_section {
 
+     /**
+     * section作成用にメソッド名と引数を配列にして返すメソッド
+     * 
+     * @param array $lib_function 
+     * @return array
+     */
     public static function random_section_array(array $lib_function){
         return ['random_section', $lib_function];
     }
 
+    /**
+     * 複数の質問をまとめて扱い、順番をランダムにするセクションを作成するための関数
+     * 
+     * 本関数を使用すると，複数の質問項目をまとめて扱い、必要に応じてページ内で表示順序を入れ替えることができる
+     * 
+     * @param array $lib_function [string 関数名, 実行する関数の引数] ライブラリに実装された関数の配列
+     */
     public static function random_section(array $lib_function){
         if (is_array($lib_function[0])){
             shuffle($lib_function);
@@ -68,6 +93,12 @@ class random_section {
     }
 }
 
+/**
+ * コールバック関数を使用するための関数。
+ * 
+ * @param string $callback
+ * @param array $val
+ */
  function run (string $callback, array $val){
     call_user_func_array(array("penguin_syan\php_form_4_expt\\$callback", $callback), $val);
 }

--- a/src/group_section.php
+++ b/src/group_section.php
@@ -9,58 +9,65 @@ namespace penguin_syan\php_form_4_expt;
  * 
  * 
  * 使用例
- * $group1 = ["random_section",
- *             [
- *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 1],
- *               ["video",'./movie.mp4', ObjectSize::SMALL, 2],
- *               ["video",'./movie.mp4', ObjectSize::SMALL, 3],
- *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 4]
- *             ]
- *           ];
- *
- * $group2 = ["random_section",
- *             [
- *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
- *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
- *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true]
- *             ]
- *           ];
- *
- * group_section([$group1,$group2]);
+ * $group1 = random_section::random_section_array(
+ *             [video::video_array('./movie.mp4', ObjectSize::SMALL_FULL , 1),
+ *              video::video_array('./movie.mp4', ObjectSize::SMALL, 2),
+ *              video::video_array('./movie.mp4', ObjectSize::SMALL, 3),
+ *              video::video_array('./movie.mp4', ObjectSize::SMALL_FULL , 4)]
+ *           );
+ * $group2 = random_section::random_section_array(
+ *              [likert_scale::likert_scale_array('次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true),
+ *               likert_scale::likert_scale_array('次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true),
+ *               likert_scale::likert_scale_array('次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true)]
+ *            );
+ * group_section::group_section([$group1,$group2]);
  * 
  * 
  * @param array $lib_function [string 関数名, 実行する関数の引数] ライブラリに実装された関数の配列
  */
+class group_section {
 
- function group_section(array $lib_function){
-    if (is_array($lib_function[0])){
-        foreach ($lib_function as $function) {
-           group_section($function);
-        }
-    } else {
-        if (count($lib_function) > 1){
-            run($lib_function[0],array_slice($lib_function, 1));
+    public static function group_section_array(array $lib_function){
+        return ['group_section', $lib_function];
+    }
+
+    public static function group_section(array $lib_function){
+        if (is_array($lib_function[0])){
+            foreach ($lib_function as $function) {
+                self::group_section($function);
+            }
         } else {
-            run($lib_function[0],[]);
+            if (count($lib_function) > 1){
+                run($lib_function[0],array_slice($lib_function, 1));
+            } else {
+                run($lib_function[0],[]);
+            }
         }
     }
- }
+}
 
- function random_section(array $lib_function){
-    if (is_array($lib_function[0])){
-        shuffle($lib_function);
-        foreach ($lib_function as $function) {
-           random_section($function);
-        }
-    } else {
-        if (count($lib_function) > 1){
-            run($lib_function[0],array_slice($lib_function, 1));
+class random_section {
+
+    public static function random_section_array(array $lib_function){
+        return ['random_section', $lib_function];
+    }
+
+    public static function random_section(array $lib_function){
+        if (is_array($lib_function[0])){
+            shuffle($lib_function);
+            foreach ($lib_function as $function) {
+                self::random_section($function);
+            }
         } else {
-            run($lib_function[0],[]);
+            if (count($lib_function) > 1){
+                run($lib_function[0],array_slice($lib_function, 1));
+            } else {
+                run($lib_function[0],[]);
+            }
         }
     }
- }
+}
 
- function run (callable $callback, array $val){
-    call_user_func_array($callback, $val);
+ function run (string $callback, array $val){
+    call_user_func_array(array($callback, $callback), $val);
 }

--- a/src/group_section.php
+++ b/src/group_section.php
@@ -5,22 +5,24 @@ namespace penguin_syan\php_form_4_expt;
  * 複数の質問をまとめて扱うセクションを作成するための関数
  * 
  * 本関数を使用すると，複数の質問項目をまとめて扱うことができる．
+ * また、必要に応じてページ内で表示順序を入れ替えることができる．
  * 
  * 
  * 使用例
- * $group1 = ["random_section",
+ * $group1 = ["penguin_syan\php_form_4_expt\\random_section",
  *             [
- *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 3],
- *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
- *               ["video",'./movie.mp4', ObjectSize::SMALL, 1]
+ *               ['penguin_syan\php_form_4_expt\\video','./movie.mp4', ObjectSize::SMALL_FULL , 1],
+ *               ["penguin_syan\php_form_4_expt\\video",'./movie.mp4', ObjectSize::SMALL, 2],
+ *               ["penguin_syan\php_form_4_expt\\video",'./movie.mp4', ObjectSize::SMALL, 3],
+ *               ['penguin_syan\php_form_4_expt\video','./movie.mp4', ObjectSize::SMALL_FULL , 4]
  *             ]
  *           ];
  *
- * $group2 = ["random_section",
+ * $group2 = ["penguin_syan\php_form_4_expt\\random_section",
  *             [
- *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 3],
- *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
- *               ["video",'./movie.mp4', ObjectSize::SMALL, 1]
+ *               ["penguin_syan\php_form_4_expt\\likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
+ *               ["penguin_syan\php_form_4_expt\\likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
+ *               ["penguin_syan\php_form_4_expt\\likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true]
  *             ]
  *           ];
  *
@@ -31,18 +33,34 @@ namespace penguin_syan\php_form_4_expt;
  */
 
  function group_section(array $lib_function){
-    foreach ($lib_function as $function) {
-        run($function[0],array_slice($function, 1));
+    if (is_array($lib_function[0])){
+        foreach ($lib_function as $function) {
+           group_section($function);
+        }
+    } else {
+        if (count($lib_function) > 1){
+            run($lib_function[0],array_slice($lib_function, 1));
+        } else {
+            run($lib_function[0],[]);
+        }
     }
  }
 
  function random_section(array $lib_function){
-    shuffle($lib_function);
-    foreach ($lib_function as $function) {
-        run($function[0],array_slice($function, 1));
+    if (is_array($lib_function[0])){
+        shuffle($lib_function);
+        foreach ($lib_function as $function) {
+           random_section($function);
+        }
+    } else {
+        if (count($lib_function) > 1){
+            run($lib_function[0],array_slice($lib_function, 1));
+        } else {
+            run($lib_function[0],[]);
+        }
     }
  }
 
- function run (callable $f, array $val){
-    call_user_func_array($f,$val);
+ function run (callable $callback, array $val){
+    call_user_func_array($callback, $val);
 }

--- a/src/group_section.php
+++ b/src/group_section.php
@@ -1,0 +1,48 @@
+<?php
+namespace penguin_syan\php_form_4_expt;
+
+/**
+ * 複数の質問をまとめて扱うセクションを作成するための関数
+ * 
+ * 本関数を使用すると，複数の質問項目をまとめて扱うことができる．
+ * 
+ * 
+ * 使用例
+ * $group1 = ["random_section",
+ *             [
+ *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 3],
+ *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
+ *               ["video",'./movie.mp4', ObjectSize::SMALL, 1]
+ *             ]
+ *           ];
+ *
+ * $group2 = ["random_section",
+ *             [
+ *               ['video','./movie.mp4', ObjectSize::SMALL_FULL , 3],
+ *               ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
+ *               ["video",'./movie.mp4', ObjectSize::SMALL, 1]
+ *             ]
+ *           ];
+ *
+ * group_section([$group1,$group2]);
+ * 
+ * 
+ * @param array $lib_function [string 関数名, 実行する関数の引数] ライブラリに実装された関数の配列
+ */
+
+ function group_section(array $lib_function){
+    foreach ($lib_function as $function) {
+        run($function[0],array_slice($function, 1));
+    }
+ }
+
+ function random_section(array $lib_function){
+    shuffle($lib_function);
+    foreach ($lib_function as $function) {
+        run($function[0],array_slice($function, 1));
+    }
+ }
+
+ function run (callable $f, array $val){
+    call_user_func_array($f,$val);
+}

--- a/src/group_section.php
+++ b/src/group_section.php
@@ -69,5 +69,5 @@ class random_section {
 }
 
  function run (string $callback, array $val){
-    call_user_func_array(array($callback, $callback), $val);
+    call_user_func_array(array("penguin_syan\php_form_4_expt\\$callback", $callback), $val);
 }

--- a/src/likert_scale.php
+++ b/src/likert_scale.php
@@ -16,27 +16,34 @@ namespace penguin_syan\php_form_4_expt;
  * @param array $choices 回答の選択肢
  * @param bool $required 回答の必須有無
  */
-function likert_scale(string $question,string $supplement,array $choices,bool $required) {
-    if ($required){
-        $req = "required";
-    } else {
-        $req = "";
+ class likert_scale {
+
+    public static function likert_scale_array(string $question,string $supplement,array $choices,bool $required) {
+        return ['likert_scale' ,$question, $supplement, $choices, $required];
     }
-    echo "<div class='question'>";
-    echo "<h4>$question</h4>";
-    echo "<p class='Qsup'>$supplement</p>";
-    echo "<div style= 'display: flex;' class = 'radioButtons'>";
-    $radioId = uniqid();
-    for ($i = 0; $i < count($choices); $i++){
-        echo "<div style= 'text-align: center;padding: 10px;'class='choices'>";
-        echo "<div>";
-        echo "<input type='radio' name='$radioId' id='$radioId-$i' value='$choices[$i]' $req>"; 
-        echo "</div>";
-        echo "<div>";
-        echo "<label for='$radioId-$i'>$choices[$i]</label>";        
+
+    public static function likert_scale(string $question,string $supplement,array $choices,bool $required) {
+        if ($required){
+            $req = "required";
+        } else {
+            $req = "";
+        }
+        echo "<div class='question'>";
+        echo "<h4>$question</h4>";
+        echo "<p class='Qsup'>$supplement</p>";
+        echo "<div style= 'display: flex;' class = 'radioButtons'>";
+        $radioId = uniqid();
+        for ($i = 0; $i < count($choices); $i++){
+            echo "<div style= 'text-align: center;padding: 10px;'class='choices'>";
+            echo "<div>";
+            echo "<input type='radio' name='$radioId' id='$radioId-$i' value='$choices[$i]' $req>"; 
+            echo "</div>";
+            echo "<div>";
+            echo "<label for='$radioId-$i'>$choices[$i]</label>";        
+            echo "</div>";
+            echo "</div>";
+        }
         echo "</div>";
         echo "</div>";
     }
-    echo "</div>";
-    echo "</div>";
 }

--- a/src/likert_scale.php
+++ b/src/likert_scale.php
@@ -2,26 +2,37 @@
 namespace penguin_syan\php_form_4_expt;
 
 /**
- * 動画を表示するための関数
+ * リッカート尺度を用いた質問を実装するためのclass
  * 
- * リッカート尺度を用いた質問を実装する関数．
- * 引数として渡された質問文，補足文を表示する．
- * また、引数として渡された回答の選択肢をラジオボタンで表示する。
- * 引数に従って，inputタグにrequiredの指定を行う．
- * 
- * 
- *
- * @param string $question 質問文
- * @param string $supplement 補足文
- * @param array $choices 回答の選択肢
- * @param bool $required 回答の必須有無
  */
  class likert_scale {
 
+    /**
+     * section作成用にメソッド名と引数を配列にして返すメソッド
+     * 
+     * @param string $question 質問文
+     * @param string $supplement 補足文
+     * @param array $choices 回答の選択肢
+     * @param bool $required 回答の必須有無
+     * @return array
+     */
     public static function likert_scale_array(string $question,string $supplement,array $choices,bool $required) {
         return ['likert_scale' ,$question, $supplement, $choices, $required];
     }
 
+    /** 
+     * リッカート尺度を用いた質問を実装する関数．
+     * 引数として渡された質問文，補足文を表示する．
+     * また、引数として渡された回答の選択肢をラジオボタンで表示する。
+     * 引数に従って，inputタグにrequiredの指定を行う．
+     * 
+     * 
+     *
+     * @param string $question 質問文
+     * @param string $supplement 補足文
+     * @param array $choices 回答の選択肢
+     * @param bool $required 回答の必須有無
+     */
     public static function likert_scale(string $question,string $supplement,array $choices,bool $required) {
         if ($required){
             $req = "required";

--- a/src/mov.php
+++ b/src/mov.php
@@ -16,116 +16,122 @@ namespace penguin_syan\php_form_4_expt;
  * @param int $max_play 再生可能回数
  */
 
-function video(string|array $filePass, int $size, int $max_play){
-    switch ($size){
-        case 0:
-            $full = "false";
-            $width = "45%";
-            break;
-        case 1:
-            $full = "false";
-            $width = "60%";
-            break;
-        case 2:
-            $full = "false";
-            $width = "80%";
-            break;
-        case 3:
-            $full = "false";
-            $width = "98%";
-            break;
-        case 4:
-            $full = "true";
-            $width = "45%";
-            break;
-        case 5:
-            $full = "true";
-            $width = "60%";
-            break;
-        case 6:
-            $full = "true";
-            $width = "80%";
-            break;
+ class video {
+    public static function video_array(string|array $filePass, int $size, int $max_play){
+        return ['video', $filePass, $size, $max_play];
     }
     
-    echo "<div id='videoField'>";
-    if (is_array($filePass)) {
-        shuffle($filePass);
-        $i = 0;
-        foreach ($filePass as $file) {
-            $max = $max_play;
-            
-            echo "<div id='video'>";
-            echo "<video src=$file width=$width></video>";
-            echo "<p id=$i class=playCount>再生可能回数：$max</p>";
-            echo "<button id=$i class=playButton>再生</button>";
-            echo "</div>";
-            $i++;
+    public static function video(string|array $filePass, int $size, int $max_play){
+        switch ($size){
+            case 0:
+                $full = "false";
+                $width = "45%";
+                break;
+            case 1:
+                $full = "false";
+                $width = "60%";
+                break;
+            case 2:
+                $full = "false";
+                $width = "80%";
+                break;
+            case 3:
+                $full = "false";
+                $width = "98%";
+                break;
+            case 4:
+                $full = "true";
+                $width = "45%";
+                break;
+            case 5:
+                $full = "true";
+                $width = "60%";
+                break;
+            case 6:
+                $full = "true";
+                $width = "80%";
+                break;
         }
-    } else {
-        echo "<div id='video'>";
-        echo "<video src=$filePass width=$width></video>";
-        echo "<p>$max_play</p>";
-        echo "<button>再生</button>";
-        echo "</div>";
-    }
-    echo "</div>";
-
-    echo <<<EOM
-    <script type="text/javascript">
-        window.onload = function(){
-            let videoField = document.getElementById('videoField');
-            videoField.oncontextmenu = function () {return false;}
-
-            let cookie = document.cookie.split(';');
-            let videos = document.querySelectorAll("#video");
-            for (let i = 0; i < videos.length; i++){
-                let video = videos[i].children[0];
-                let p = videos[i].children[1];
-                let btn = videos[i].children[2];
-                let reload = false;
-                let pNum = p.innerText.slice(-1);
-                cookie.forEach(function(value) {
-                    value = value.replace(/\s+/g, "");
-                    let content = value.split('=');
-                    if (content[0] == document.domain + String(i)) {
-                        reload = true;
-                        pNum = content[1];
-                        console.log(pNum);
-                    }
-                })
-                if (reload === false) {
-                    document.cookie = document.domain + String(i) + '=' + p.innerText.slice(-1);
-                }
-                p.innerText = "再生可能回数："+ pNum;
-                if (parseInt(pNum)<= 0){
-                    btn.disabled = true;
-                } else {
-                    btn.disabled = false;
-                }
-                let clickFunc = function() {
-                    pNum = parseInt(pNum) - 1;
+        
+        echo "<div id='videoField'>";
+        if (is_array($filePass)) {
+            shuffle($filePass);
+            $i = 0;
+            foreach ($filePass as $file) {
+                $max = $max_play;
                 
-                    let width = video.style.width;
-                    video.addEventListener("ended", function(){
-                        if (parseInt(pNum) > 0){
-                            btn.disabled = false;
-                        }
-                        if($full){
-                            video.style.width = width;
-                        }
-                    }, false);
-                    if($full){
-                        video.style.width = '98%';
-                    }
-                    video.play();
-                    btn.disabled = true;
-                    document.cookie = document.domain + String(i) + '=' + pNum;
-                    p.innerText = "再生可能回数："+ pNum;
-                }
-                btn.addEventListener("click",clickFunc);
+                echo "<div id='video'>";
+                echo "<video src=$file width=$width></video>";
+                echo "<p id=$i class=playCount>再生可能回数：$max</p>";
+                echo "<button id=$i class=playButton>再生</button>";
+                echo "</div>";
+                $i++;
             }
+        } else {
+            echo "<div id='video'>";
+            echo "<video src=$filePass width=$width></video>";
+            echo "<p>$max_play</p>";
+            echo "<button>再生</button>";
+            echo "</div>";
         }
-    </script>
-    EOM;
+        echo "</div>";
+
+        echo <<<EOM
+        <script type="text/javascript">
+            window.onload = function(){
+                let videoField = document.getElementById('videoField');
+                videoField.oncontextmenu = function () {return false;}
+
+                let cookie = document.cookie.split(';');
+                let videos = document.querySelectorAll("#video");
+                for (let i = 0; i < videos.length; i++){
+                    let video = videos[i].children[0];
+                    let p = videos[i].children[1];
+                    let btn = videos[i].children[2];
+                    let reload = false;
+                    let pNum = p.innerText.slice(-1);
+                    cookie.forEach(function(value) {
+                        value = value.replace(/\s+/g, "");
+                        let content = value.split('=');
+                        if (content[0] == document.domain + String(i)) {
+                            reload = true;
+                            pNum = content[1];
+                            console.log(pNum);
+                        }
+                    })
+                    if (reload === false) {
+                        document.cookie = document.domain + String(i) + '=' + p.innerText.slice(-1);
+                    }
+                    p.innerText = "再生可能回数："+ pNum;
+                    if (parseInt(pNum)<= 0){
+                        btn.disabled = true;
+                    } else {
+                        btn.disabled = false;
+                    }
+                    let clickFunc = function() {
+                        pNum = parseInt(pNum) - 1;
+                    
+                        let width = video.style.width;
+                        video.addEventListener("ended", function(){
+                            if (parseInt(pNum) > 0){
+                                btn.disabled = false;
+                            }
+                            if($full){
+                                video.style.width = width;
+                            }
+                        }, false);
+                        if($full){
+                            video.style.width = '98%';
+                        }
+                        video.play();
+                        btn.disabled = true;
+                        document.cookie = document.domain + String(i) + '=' + pNum;
+                        p.innerText = "再生可能回数："+ pNum;
+                    }
+                    btn.addEventListener("click",clickFunc);
+                }
+            }
+        </script>
+        EOM;
+    }
 }

--- a/src/mov.php
+++ b/src/mov.php
@@ -1,26 +1,37 @@
 <?php
 namespace penguin_syan\php_form_4_expt;
 
-/**
- * 動画を表示するための関数
- * 
- * 本関数を使用すると，引数として渡された画像を<video>タグを用いて表示する．
- * この時，引数として渡されたパラメータをもとに画像のサイズを設定する．
- * また、引数として渡されたパラメータをもとに再生時に全画面サイズで表示を行う。
- * 引数として渡された画像のpassが配列の場合ランダムな順番で表示する．
- * 
- * 
- *
- * @param string|array $filePass 画像のpass
- * @param int $size 画像の大きさ
- * @param int $max_play 再生可能回数
- */
 
+/**
+ * 動画を表示するためのclass
+ */
  class video {
+    /**
+     * section作成用にメソッド名と引数を配列にして返すメソッド
+     * 
+     * @param string|array $filePass 画像のpass
+     * @param int $size 画像の大きさ
+     * @param int $max_play 再生可能回数
+     * @return array
+     */
     public static function video_array(string|array $filePass, int $size, int $max_play){
         return ['video', $filePass, $size, $max_play];
     }
-    
+
+    /**
+     * 動画を表示するための関数
+     * 
+     * 本関数を使用すると，引数として渡された画像を<video>タグを用いて表示する．
+     * この時，引数として渡されたパラメータをもとに画像のサイズを設定する．
+     * また、引数として渡されたパラメータをもとに再生時に全画面サイズで表示を行う。
+     * 引数として渡された画像のpassが配列の場合ランダムな順番で表示する．
+     * 
+     * 
+     *
+     * @param string|array $filePass 画像のpass
+     * @param int $size 画像の大きさ
+     * @param int $max_play 再生可能回数
+     */
     public static function video(string|array $filePass, int $size, int $max_play){
         switch ($size){
             case 0:

--- a/src/mov.php
+++ b/src/mov.php
@@ -63,7 +63,7 @@ namespace penguin_syan\php_form_4_expt;
                 echo "<div id='video'>";
                 echo "<video src=$file width=$width></video>";
                 echo "<p id=$i class=playCount>再生可能回数：$max</p>";
-                echo "<button id=$i class=playButton>再生</button>";
+                echo "<button type=\"button\" id=$i class=playButton>再生</button>";
                 echo "</div>";
                 $i++;
             }
@@ -71,7 +71,7 @@ namespace penguin_syan\php_form_4_expt;
             echo "<div id='video'>";
             echo "<video src=$filePass width=$width></video>";
             echo "<p>$max_play</p>";
-            echo "<button>再生</button>";
+            echo "<button type=\"button\">再生</button>";
             echo "</div>";
         }
         echo "</div>";


### PR DESCRIPTION
**変更の概要**  
複数の質問をまとめて扱うセクションを作成するための関数の追加

**変更理由**  
複数の質問をまとめて扱うセクションの実装

**変更内容**  
group_sectionとrandom_sectionの追加

**課題**  
コールバック関数の実装の都合上、関数をそのまま代入することは難しいため、[string 関数名, 実行する関数の引数]を引数として実装した。そのため、要件と少し差異があり、引数が少し理解しにくい。

一応以下のように使用はできる。

```
$group1 = [random_section",
           [
            ['video','./movie.mp4', ObjectSize::SMALL_FULL , 1],
            ["video",'./movie.mp4', ObjectSize::SMALL, 2],
            ["video",'./movie.mp4', ObjectSize::SMALL, 3],
            ['video','./movie.mp4', ObjectSize::SMALL_FULL , 4]
           ]
          ];

$group2 = ["random_section",
           [
            ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
            ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true],
            ["likert_scale",'次のうち当てはまるものを選択してください．','迷わず，直感的に選択してください',['非常に同意する', '同意する', 'やや同意する', 'どちらともいえない', 'やや同意しない', '同意しない', '全く同意しない'],true]
           ]
          ];
group_section([$group1,$group2]);
```

**備考**  
もうちょっと上手く実装できないかなと思ったけど、phpの機能的に今の感じになるかなと思う。いいアイディアがあれば変更してもいいかも。